### PR TITLE
Corrigendum #2

### DIFF
--- a/srfi-126.html
+++ b/srfi-126.html
@@ -312,7 +312,7 @@ class="antispam">nospam</span>srfi.schemers.org</a></code>. To subscribe to the 
 <ul>
 <li><code>(hash-salt)</code> <em>syntax</em></li>
 </ul>
-<p>Expands to an exact non-negative integer that lies within the fixnum range of the implementation. The value that is expanded to remains constant throughout the execution of the program. It is initialized randomly for every run of the program, except when the environment variable <code>SRFI_126_HASH_SEED</code> is set to a non-empty string before program startup, in which case it is derived from the value of that environment variable in a deterministic manner.</p>
+<p>Expands to a form evaluating to an exact non-negative integer that lies within the fixnum range of the implementation. The value the expanded form evaluates to remains constant throughout the execution of the program. It is random for every run of the program, except when the environment variable <code>SRFI_126_HASH_SEED</code> is set to a non-empty string before program startup, in which case it is derived from the value of that environment variable in a deterministic manner.</p>
 <ul>
 <li><code>(equal-hash obj)</code> <em>procedure</em></li>
 </ul>

--- a/srfi-126.md
+++ b/srfi-126.md
@@ -666,13 +666,13 @@ derived from that string in a deterministic manner.
 
 - `(hash-salt)` *syntax*
 
-Expands to an exact non-negative integer that lies within the fixnum
-range of the implementation.  The value that is expanded to remains
-constant throughout the execution of the program.  It is initialized
-randomly for every run of the program, except when the environment
-variable `SRFI_126_HASH_SEED` is set to a non-empty string before
-program startup, in which case it is derived from the value of that
-environment variable in a deterministic manner.
+Expands to a form evaluating to an exact non-negative integer that
+lies within the fixnum range of the implementation.  The value the
+expanded form evaluates to remains constant throughout the execution
+of the program.  It is random for every run of the program, except
+when the environment variable `SRFI_126_HASH_SEED` is set to a
+non-empty string before program startup, in which case it is derived
+from the value of that environment variable in a deterministic manner.
 
 - `(equal-hash obj)` *procedure*
 

--- a/srfi/126.body.scm
+++ b/srfi/126.body.scm
@@ -56,7 +56,7 @@
      (let ((hashtable (make-hashtable hash equiv capacity weakness)))
        (for-each (lambda (entry)
                    (hashtable-set! hashtable (car entry) (cdr entry)))
-                 alist)
+                 (reverse alist))
        hashtable))))
 
 (define-enumeration weakness

--- a/srfi/126.sld
+++ b/srfi/126.sld
@@ -89,7 +89,7 @@
      (let ((hashtable (make-hashtable hash equiv capacity weakness)))
        (for-each (lambda (entry)
                    (hashtable-set! hashtable (car entry) (cdr entry)))
-                 alist)
+                 (reverse alist))
        hashtable))))
 
 (define-enumeration weakness

--- a/srfi/:126.sls
+++ b/srfi/:126.sls
@@ -87,7 +87,7 @@
      (let ((hashtable (make-hashtable hash equiv capacity weakness)))
        (for-each (lambda (entry)
                    (hashtable-set! hashtable (car entry) (cdr entry)))
-                 alist)
+                 (reverse alist))
        hashtable))))
 
 (define-enumeration weakness

--- a/srfi/srfi-126.scm
+++ b/srfi/srfi-126.scm
@@ -98,7 +98,7 @@
      (let ((ht (make-hashtable hash equiv capacity weakness)))
        (for-each (lambda (entry)
                    (hashtable-set! ht (car entry) (cdr entry)))
-                 alist)
+                 (reverse alist))
        ht))))
 
 (define-syntax weakness

--- a/test-suite.body.scm
+++ b/test-suite.body.scm
@@ -63,7 +63,18 @@
         (let ((hash (hashtable-hash-function table)))
           (test-assert (or (eq? equal-hash hash)
                            (and (eq? equal-hash (car hash))
-                                (eq? equal-hash (cdr hash))))))))))
+                                (eq? equal-hash (cdr hash)))))))))
+  (test-group "alist"
+    (let ((tables (list (alist->eq-hashtable '((a . b) (a . c)))
+                        (alist->eqv-hashtable '((a . b) (a . c)))
+                        (alist->hashtable equal-hash equal?
+                                          '((a . b) (a . c))))))
+      (do ((tables tables (cdr tables))
+           (i 0 (+ i 1)))
+          ((null? tables))
+        (let ((table (car tables))
+              (label (number->string i)))
+          (test-eq label 'b (hashtable-ref table 'a)))))))
 
 (test-group "procedures"
   (test-group "basics"

--- a/test-suite.r6rs.sps
+++ b/test-suite.r6rs.sps
@@ -77,7 +77,18 @@
         (let ((hash (hashtable-hash-function table)))
           (test-assert (or (eq? equal-hash hash)
                            (and (eq? equal-hash (car hash))
-                                (eq? equal-hash (cdr hash))))))))))
+                                (eq? equal-hash (cdr hash)))))))))
+  (test-group "alist"
+    (let ((tables (list (alist->eq-hashtable '((a . b) (a . c)))
+                        (alist->eqv-hashtable '((a . b) (a . c)))
+                        (alist->hashtable equal-hash equal?
+                                          '((a . b) (a . c))))))
+      (do ((tables tables (cdr tables))
+           (i 0 (+ i 1)))
+          ((null? tables))
+        (let ((table (car tables))
+              (label (number->string i)))
+          (test-eq label 'b (hashtable-ref table 'a)))))))
 
 (test-group "procedures"
   (test-group "basics"

--- a/test-suite.r7rs.scm
+++ b/test-suite.r7rs.scm
@@ -71,7 +71,18 @@
         (let ((hash (hashtable-hash-function table)))
           (test-assert (or (eq? equal-hash hash)
                            (and (eq? equal-hash (car hash))
-                                (eq? equal-hash (cdr hash))))))))))
+                                (eq? equal-hash (cdr hash)))))))))
+  (test-group "alist"
+    (let ((tables (list (alist->eq-hashtable '((a . b) (a . c)))
+                        (alist->eqv-hashtable '((a . b) (a . c)))
+                        (alist->hashtable equal-hash equal?
+                                          '((a . b) (a . c))))))
+      (do ((tables tables (cdr tables))
+           (i 0 (+ i 1)))
+          ((null? tables))
+        (let ((table (car tables))
+              (label (number->string i)))
+          (test-eq label 'b (hashtable-ref table 'a)))))))
 
 (test-group "procedures"
   (test-group "basics"


### PR DESCRIPTION
The first commit just fixes the sample implementations and test suite according to corrigendum #1.

The second commit fixes the specified semantics of hash-salt, which was already different (correct) in the sample implementation. This correction was noted much earlier on the ML, before I became aware of the errata process.
